### PR TITLE
impl async iterable for children

### DIFF
--- a/app/pages/index.js
+++ b/app/pages/index.js
@@ -65,6 +65,7 @@ export default () => ({
       styles: {
         margin: 0
       },
+      asyncIterable: true,
       hooks: {
         async init() {
           console.log('Body init');

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,5 +1,6 @@
 import MainComponent from '/app/main.js';
 import PreloadComponents from '/app/preload.js';
+import { asyncIterable } from "./utils.js";
 
 const bindText = (schema, element, initialText) => {
   Reflect.defineProperty(schema, 'text', {
@@ -116,17 +117,24 @@ class ComponentChildren extends Array {
     void this.#compileChildren(children);
   }
 
-  #compileChild(schema) {
+  async #compileChild(children, child) {
+    const schema = await ComponentChildren.#loadChildSchema(child);
+    const index = children.indexOf(child);
+    this.#parentSchema.children[index] = schema;
     schema.parent = this.#parentSchema;
     compile(schema, this.#parentElement);
   }
 
   async #compileChildren(children) {
-    for (const child of children) {
-      const schema = await ComponentChildren.#loadChildSchema(child);
-      const index = children.indexOf(child);
-      this.#parentSchema.children[index] = schema;
-      this.#compileChild(schema);
+    if (this.#parentSchema.asyncIterable) {
+      children[Symbol.asyncIterator] = asyncIterable;
+      for await (const child of children) {
+        await this.#compileChild(children, child);
+      }
+    } else {
+      for (const child of children) {
+        await this.#compileChild(children, child);
+      }
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,15 @@
+export function asyncIterable () {
+    let i = 0;
+    return {
+        next: () => {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    resolve({
+                        value: this[i],
+                        done: i++ === this.length,
+                    });
+                }, 0);
+            });
+        },
+    };
+}


### PR DESCRIPTION
### :rocket: Improvements
This is a suggestion to make schema's child arrays async iterable to improve compiler performance.

NOTE: Taken @tshemsedinov s implementation of the async iterable contract for arrays.
